### PR TITLE
Only bind localhost if config.hosts is unset

### DIFF
--- a/server/source/zrenderer/server/package.d
+++ b/server/source/zrenderer/server/package.d
@@ -100,7 +100,8 @@ int main(string[] args)
     }
 
     auto settings = new HTTPServerSettings;
-    settings.bindAddresses = config.hosts;
+    auto bindHosts = config.hosts.length > 0 ? config.hosts : ["localhost"];
+    settings.bindAddresses = bindHosts;
     settings.port = config.port;
     settings.accessLogFormat = "%h - %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" \"%{x-token-desc}i\"";
     settings.accessLogger = new MaskedConsoleLogger(settings, settings.accessLogFormat);

--- a/source/config.d
+++ b/source/config.d
@@ -192,7 +192,7 @@ struct Config
     @Section("server")
     {
         @Desc("Hostnames of the server. Can contain multiple comma separated values.")
-        string[] hosts = ["localhost"];
+        string[] hosts = [];
 
         @Desc("Port of the server.")
         ushort port = 11011;


### PR DESCRIPTION
I ran into an issue deploying the container using Docker -- config.hosts seems to be additive, so any subsequent hosts values set in zrenderer.conf are appended to the default value of localhost. When starting the Docker container, the default bind to `localhost` would succeed, but the subsequent bind to `0.0.0.0` or `::` would fail, I assume because localhost was already bound.

This didn't reproduce for me using Podman, so possibly it's an issue with my Docker setup, but changing the server to only include `localhost` if config.hosts is unset fixed the issue for me.

I'm not too familiar with the code, so please let me know if this isn't the right change to make, thanks!
